### PR TITLE
Updated name

### DIFF
--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,4 @@
-name: 'OpenShift'
+name: 'OpenShift Action'
 description: 'This action allows you to connect to an OpenShift cluster and execute oc commands on it'
 author: 'Red Hat'
 branding:


### PR DESCRIPTION
GitHub marketplace doesn't allow to use OpenShift as name for this extension. Name must be unique. Cannot match an existing action, user or organization name.