### PR TITLE
fixed error with path external json

### DIFF
--- a/lib/src/installer.js
+++ b/lib/src/installer.js
@@ -27,7 +27,7 @@ class Installer {
                 url = version;
             }
             else {
-                url = yield Installer.getOcBundleUrl(version, runnerOS);
+                url = Installer.getOcBundleUrl(version, runnerOS);
             }
             core.debug(`downloading: ${url}`);
             return yield Installer.downloadAndExtract(url, runnerOS);
@@ -59,84 +59,77 @@ class Installer {
         });
     }
     static getOcBundleUrl(version, runnerOS) {
-        return __awaiter(this, void 0, void 0, function* () {
-            let url = '';
-            if (version === 'latest') {
-                url = yield Installer.latest(runnerOS);
-                return url;
-            }
-            // determine the base_url based on version
-            const reg = new RegExp('\\d+(?=\\.)');
-            const vMajorRegEx = reg.exec(version);
-            if (!vMajorRegEx || vMajorRegEx.length === 0) {
-                core.debug('Error retrieving version major');
-                return null;
-            }
-            const vMajor = +vMajorRegEx[0];
-            const ocUtils = yield Installer.getOcUtils();
-            if (vMajor === 3) {
-                url = `${ocUtils.openshiftV3BaseUrl}/${version}/`;
-            }
-            else if (vMajor === 4) {
-                url = `${ocUtils.openshiftV4BaseUrl}/${version}/`;
-            }
-            else {
-                core.debug('Invalid version');
-                return null;
-            }
-            const bundle = yield Installer.getOcBundleByOS(runnerOS);
-            if (!bundle) {
-                core.debug('Unable to find bundle url');
-                return null;
-            }
-            url += bundle;
-            core.debug(`archive URL: ${url}`);
+        let url = '';
+        if (version === 'latest') {
+            url = Installer.latest(runnerOS);
             return url;
-        });
+        }
+        // determine the base_url based on version
+        const reg = new RegExp('\\d+(?=\\.)');
+        const vMajorRegEx = reg.exec(version);
+        if (!vMajorRegEx || vMajorRegEx.length === 0) {
+            core.debug('Error retrieving version major');
+            return null;
+        }
+        const vMajor = +vMajorRegEx[0];
+        const ocUtils = Installer.getOcUtils();
+        if (vMajor === 3) {
+            url = `${ocUtils.openshiftV3BaseUrl}/${version}/`;
+        }
+        else if (vMajor === 4) {
+            url = `${ocUtils.openshiftV4BaseUrl}/${version}/`;
+        }
+        else {
+            core.debug('Invalid version');
+            return null;
+        }
+        const bundle = Installer.getOcBundleByOS(runnerOS);
+        if (!bundle) {
+            core.debug('Unable to find bundle url');
+            return null;
+        }
+        url += bundle;
+        core.debug(`archive URL: ${url}`);
+        return url;
     }
     static latest(runnerOS) {
-        return __awaiter(this, void 0, void 0, function* () {
-            const bundle = yield Installer.getOcBundleByOS(runnerOS);
-            if (!bundle) {
-                core.debug('Unable to find bundle url');
-                return null;
-            }
-            const ocUtils = yield Installer.getOcUtils();
-            const url = `${ocUtils.openshiftV4BaseUrl}/${constants_1.LATEST}/${bundle}`;
-            core.debug(`latest stable oc version: ${url}`);
-            return url;
-        });
+        const bundle = Installer.getOcBundleByOS(runnerOS);
+        if (!bundle) {
+            core.debug('Unable to find bundle url');
+            return null;
+        }
+        const ocUtils = Installer.getOcUtils();
+        const url = `${ocUtils.openshiftV4BaseUrl}/${constants_1.LATEST}/${bundle}`;
+        core.debug(`latest stable oc version: ${url}`);
+        return url;
     }
     static getOcBundleByOS(runnerOS) {
-        return __awaiter(this, void 0, void 0, function* () {
-            let url = '';
-            // determine the bundle path based on the OS type
-            switch (runnerOS) {
-                case 'Linux': {
-                    url += `${constants_1.LINUX}/${constants_1.OC_TAR_GZ}`;
-                    break;
-                }
-                case 'macOS': {
-                    url += `${constants_1.MACOSX}/${constants_1.OC_TAR_GZ}`;
-                    break;
-                }
-                case 'Windows': {
-                    url += `${constants_1.WIN}/${constants_1.OC_ZIP}`;
-                    break;
-                }
-                default: {
-                    return null;
-                }
+        let url = '';
+        // determine the bundle path based on the OS type
+        switch (runnerOS) {
+            case 'Linux': {
+                url += `${constants_1.LINUX}/${constants_1.OC_TAR_GZ}`;
+                break;
             }
-            return url;
-        });
+            case 'macOS': {
+                url += `${constants_1.MACOSX}/${constants_1.OC_TAR_GZ}`;
+                break;
+            }
+            case 'Windows': {
+                url += `${constants_1.WIN}/${constants_1.OC_ZIP}`;
+                break;
+            }
+            default: {
+                return null;
+            }
+        }
+        return url;
     }
     static getOcUtils() {
-        return __awaiter(this, void 0, void 0, function* () {
-            const workspace = process.env['GITHUB_WORKSPACE'] || '';
-            const rawData = yield fs.readFile(path.join(workspace, 'oc-utils.json'));
-            return JSON.parse(rawData);
-        });
+        return {
+            "openshiftV3BaseUrl": "https://mirror.openshift.com/pub/openshift-v3/clients",
+            "openshiftV4BaseUrl": "https://mirror.openshift.com/pub/openshift-v4/clients/oc"
+        };
     }
 }
 exports.Installer = Installer;

--- a/oc-utils.json
+++ b/oc-utils.json
@@ -1,4 +1,0 @@
-{
-    "openshiftV3BaseUrl": "https://mirror.openshift.com/pub/openshift-v3/clients",
-    "openshiftV4BaseUrl": "https://mirror.openshift.com/pub/openshift-v4/clients/oc"
-}

--- a/src/installer.ts
+++ b/src/installer.ts
@@ -15,7 +15,7 @@ export class Installer {
         if (validUrl.isWebUri(version)) {
             url = version;
         } else {
-            url = await Installer.getOcBundleUrl(version, runnerOS);
+            url = Installer.getOcBundleUrl(version, runnerOS);
         }
 
         core.debug(`downloading: ${url}`);
@@ -47,10 +47,10 @@ export class Installer {
         }
     }
 
-    static async getOcBundleUrl(version: string, runnerOS: string): Promise<string> {
+    static getOcBundleUrl(version: string, runnerOS: string): string {
         let url = '';
         if (version === 'latest') {
-            url = await Installer.latest(runnerOS);
+            url = Installer.latest(runnerOS);
             return url;
         }
 
@@ -63,7 +63,7 @@ export class Installer {
         }
         const vMajor: number = +vMajorRegEx[0];
 
-        const ocUtils = await Installer.getOcUtils();
+        const ocUtils = Installer.getOcUtils();
         if (vMajor === 3) {
             url = `${ocUtils.openshiftV3BaseUrl}/${version}/`;
         } else if (vMajor === 4) {
@@ -73,7 +73,7 @@ export class Installer {
             return null;
         }
 
-        const bundle = await Installer.getOcBundleByOS(runnerOS);
+        const bundle = Installer.getOcBundleByOS(runnerOS);
         if (!bundle) {
             core.debug('Unable to find bundle url');
             return null;
@@ -85,21 +85,21 @@ export class Installer {
         return url;
     }
 
-    static async latest(runnerOS: string): Promise<string> {
-        const bundle = await Installer.getOcBundleByOS(runnerOS);
+    static latest(runnerOS: string): string {
+        const bundle = Installer.getOcBundleByOS(runnerOS);
         if (!bundle) {
             core.debug('Unable to find bundle url');
             return null;
         }
 
-        const ocUtils = await Installer.getOcUtils();
+        const ocUtils = Installer.getOcUtils();
         const url = `${ocUtils.openshiftV4BaseUrl}/${LATEST}/${bundle}`;
 
         core.debug(`latest stable oc version: ${url}`);
         return url;
     }
 
-    static async getOcBundleByOS(runnerOS: string): Promise<string | null> {
+    static getOcBundleByOS(runnerOS: string): string | null {
         let url = '';
         // determine the bundle path based on the OS type
         switch (runnerOS) {
@@ -122,9 +122,10 @@ export class Installer {
         return url;
     }
 
-    static async getOcUtils(): Promise<{ [key: string]: string }> {
-        const workspace = process.env['GITHUB_WORKSPACE'] || '';
-        const rawData = await fs.readFile(path.join(workspace, 'oc-utils.json'));
-        return JSON.parse(rawData);
+    static getOcUtils(): { [key: string]: string } {
+        return {
+            "openshiftV3BaseUrl": "https://mirror.openshift.com/pub/openshift-v3/clients",
+            "openshiftV4BaseUrl": "https://mirror.openshift.com/pub/openshift-v4/clients/oc"
+        };
     }
 }

--- a/test/installer.test.ts
+++ b/test/installer.test.ts
@@ -35,7 +35,7 @@ suite('Installer', () => {
         });
 
         test('check if getOcBundleUrl called if version is not URL', async () => {
-            const getOcBundleStub = sandbox.stub(Installer, 'getOcBundleUrl').resolves('url');
+            const getOcBundleStub = sandbox.stub(Installer, 'getOcBundleUrl').returns('url');
             sandbox.stub(Installer, 'downloadAndExtract').resolves('ocbinary');
             await Installer.installOc('3.11', 'OS');
             expect(getOcBundleStub).calledOnceWith('3.11', 'OS');
@@ -43,14 +43,14 @@ suite('Installer', () => {
 
         test('check if getOcBundleUrl NOT called if version is not URL', async () => {
             sandbox.stub(validUrl, 'isWebUri').returns(true);
-            const getOcBundleStub = sandbox.stub(Installer, 'getOcBundleUrl').resolves('url');
+            const getOcBundleStub = sandbox.stub(Installer, 'getOcBundleUrl').returns('url');
             sandbox.stub(Installer, 'downloadAndExtract').resolves('ocbinary');
             await Installer.installOc('url', 'OS');
             expect(getOcBundleStub).not.called;
         });
 
         test('check if correct oc binary path is returned', async () => {
-            sandbox.stub(Installer, 'getOcBundleUrl').resolves('url');
+            sandbox.stub(Installer, 'getOcBundleUrl').returns('url');
             const downloadExtractStub = sandbox.stub(Installer, 'downloadAndExtract').resolves('ocbinary');
             const res = await Installer.installOc('3.11', 'OS');
             expect(downloadExtractStub).calledOnceWith('url', 'OS');
@@ -128,41 +128,41 @@ suite('Installer', () => {
         };
 
         test('check if latest url returned if request latest oc version', async () => {
-            const latestStub = sandbox.stub(Installer, 'latest').resolves('urllatest');
-            const res = await Installer.getOcBundleUrl('latest', 'OS');
+            const latestStub = sandbox.stub(Installer, 'latest').returns('urllatest');
+            const res = Installer.getOcBundleUrl('latest', 'OS');
             expect(latestStub).calledOnceWith('OS');
             expect(res).equals('urllatest');
         });
 
         test('return null if version is not in valid format', async () => {
-            const res = await Installer.getOcBundleUrl('invalidversion', 'OS');
+            const res = Installer.getOcBundleUrl('invalidversion', 'OS');
             expect(res).equals(null);
         });
 
         test('check if valid url is returned if major version is 3', async () => {
-            sandbox.stub(Installer, 'getOcUtils').resolves(ocUtils);
-            sandbox.stub(Installer, 'getOcBundleByOS').resolves('ocbundle');
-            const res = await Installer.getOcBundleUrl('3.11', 'OS');
+            sandbox.stub(Installer, 'getOcUtils').returns(ocUtils);
+            sandbox.stub(Installer, 'getOcBundleByOS').returns('ocbundle');
+            const res = Installer.getOcBundleUrl('3.11', 'OS');
             expect(res).equals('urlv3/3.11/ocbundle');
         });
 
         test('check if valid url is returned if major version is 4', async () => {
-            sandbox.stub(Installer, 'getOcUtils').resolves(ocUtils);
-            sandbox.stub(Installer, 'getOcBundleByOS').resolves('ocbundle');
-            const res = await Installer.getOcBundleUrl('4.1', 'OS');
+            sandbox.stub(Installer, 'getOcUtils').returns(ocUtils);
+            sandbox.stub(Installer, 'getOcBundleByOS').returns('ocbundle');
+            const res = Installer.getOcBundleUrl('4.1', 'OS');
             expect(res).equals('urlv4/4.1/ocbundle');
         });
 
         test('null if major version is neither 3 nor 4', async () => {
-            sandbox.stub(Installer, 'getOcUtils').resolves(ocUtils);
-            const res = await Installer.getOcBundleUrl('2.1', 'OS');
+            sandbox.stub(Installer, 'getOcUtils').returns(ocUtils);
+            const res = Installer.getOcBundleUrl('2.1', 'OS');
             expect(res).equals(null);
         });
 
         test('null if unable to find oc bundle url', async () => {
-            sandbox.stub(Installer, 'getOcUtils').resolves(ocUtils);
-            const ocBundleStub = sandbox.stub(Installer, 'getOcBundleByOS').resolves(null);
-            const res = await Installer.getOcBundleUrl('4.1', 'OS');
+            sandbox.stub(Installer, 'getOcUtils').returns(ocUtils);
+            const ocBundleStub = sandbox.stub(Installer, 'getOcBundleByOS').returns(null);
+            const res = Installer.getOcBundleUrl('4.1', 'OS');
             expect(ocBundleStub).calledOnceWith('OS');
             expect(res).equals(null);
         });
@@ -170,60 +170,48 @@ suite('Installer', () => {
 
     suite('latest', () => {
         test('returns null if oc bundle url not found', async () => {
-            sandbox.stub(Installer, 'getOcBundleByOS').resolves(null);
-            const res = await Installer.latest('OS');
+            sandbox.stub(Installer, 'getOcBundleByOS').returns(null);
+            const res = Installer.latest('OS');
             expect(res).equals(null);
         });
 
         test('check if latest oc version is returned if bundle url is found', async () => {
-            const ocUtils = {
-                'openshiftV3BaseUrl': 'urlv3',
-                'openshiftV4BaseUrl': 'urlv4'
-            };
-            const ocBundleStub = sandbox.stub(Installer, 'getOcBundleByOS').resolves('ocbundle');
-            sandbox.stub(Installer, 'getOcUtils').resolves(ocUtils);
-            const res = await Installer.latest('OS');
+            const ocBundleStub = sandbox.stub(Installer, 'getOcBundleByOS').returns('ocbundle');
+            const res = Installer.latest('OS');
             expect(ocBundleStub).calledOnceWith('OS');
-            expect(res).equals('urlv4/latest/ocbundle');
+            expect(res).equals('https://mirror.openshift.com/pub/openshift-v4/clients/oc/latest/ocbundle');
         });
     });
 
     suite('getOcBundleByOS', () => {
         test('check if correct url is returned if OS is Windows', async () => {
-            const res = await Installer.getOcBundleByOS('Windows');
+            const res = Installer.getOcBundleByOS('Windows');
             expect(res).equals('windows/oc.zip');
         });
 
         test('check if correct url is returned if OS is Linux', async () => {
-            const res = await Installer.getOcBundleByOS('Linux');
+            const res = Installer.getOcBundleByOS('Linux');
             expect(res).equals('linux/oc.tar.gz');
         });
 
         test('check if correct url is returned if OS is MacOS', async () => {
-            const res = await Installer.getOcBundleByOS('macOS');
+            const res = Installer.getOcBundleByOS('macOS');
             expect(res).equals('macosx/oc.tar.gz');
         });
 
         test('returns null with invalid OS', async () => {
-            const res = await Installer.getOcBundleByOS('OS');
+            const res = Installer.getOcBundleByOS('OS');
             expect(res).equals(null);
         });
     });
 
     suite('getOcUtils', () => {
         test('check if readfile is called with right params', async () => {
-            const ocUtils = `{
-                "openshiftV3BaseUrl": "urlv3",
-                "openshiftV4BaseUrl": "urlv4"
-            }`;
             const ocUtilsJSON = {
-                openshiftV3BaseUrl: 'urlv3',
-                openshiftV4BaseUrl: 'urlv4'
+                openshiftV3BaseUrl: 'https://mirror.openshift.com/pub/openshift-v3/clients',
+                openshiftV4BaseUrl: 'https://mirror.openshift.com/pub/openshift-v4/clients/oc'
             };
-            process.env.GITHUB_WORKSPACE = 'path';
-            const readFileStub = sandbox.stub(fs, 'readFile').resolves(ocUtils);
-            const res = await Installer.getOcUtils();
-            expect(readFileStub).calledOnceWith('path/oc-utils.json');
+            const res = Installer.getOcUtils();
             expect(res).deep.equals(ocUtilsJSON);
         });
     });


### PR DESCRIPTION
While i was writing the blog, i tested the action with self-hosted runner to see if it also worked with it. I found that there is an issue when finding the path of the external json. Fixed that part by removing the external file bc there is no way to find the correct path in a nice way atm. 

The env variables available refer to the workspace where the code of the repo is stored, not the action. (let's suppose you want to run our action inside your repo app1, the workspace path will point to the copy of that repo (_work/app1/) and not the code of our action (_work/_action/) ....). There is no way to find by code the current version of the OpenShift action which is running and this complicates a bit how to find the correct position of our json. 